### PR TITLE
Prevent conda from reverting the geocat-viz version.

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -10,7 +10,7 @@ dependencies:
   - matplotlib
   - cartopy
   - metpy
-  - geocat-viz=2023.10.0
+  - geocat-viz>=2023.10.0
   - colorcet
   - hvplot
   - plotly

--- a/environment.yml
+++ b/environment.yml
@@ -10,7 +10,7 @@ dependencies:
   - matplotlib
   - cartopy
   - metpy
-  - geocat-viz
+  - geocat-viz=2023.10.0
   - colorcet
   - hvplot
   - plotly


### PR DESCRIPTION
Conda is currently using an older version of geocat-viz that doesn't work with this content.  

This changes up the environment file to prevent that from happening.
