### PR TITLE
Tidy up environment

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -2,10 +2,10 @@ name: advanced-viz-cookbook
 channels:
   - conda-forge
 dependencies:
-  - python>=3.9,<3.12
+  - sphinx-pythia-theme
   - jupyter-book
   - jupyterlab
-  - jupyter_server
+  - jupyter_bokeh
   - pandas
   - matplotlib
   - cartopy
@@ -20,7 +20,3 @@ dependencies:
   - geocat-datafiles
   - geoviews
   - tropycal
-  - sphinx-pythia-theme
-  - pip
-  - pip:
-      - jupyter_bokeh


### PR DESCRIPTION
This just removes some environment pins and packages that I don't think we actually need and moves everything to conda-forge to avoid the need for pip.  It does also make the environment a bit smaller without needing to alter the notebooks.

Maybe we can give this a go and then see if we need to remove packages.
