### PR TITLE
Missing nightly build badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 <img src="thumbnail.png" alt="thumbnail" width="300"/>
 
+[![nightly-build](https://github.com/ProjectPythia/advanced-viz-cookbook/actions/workflows/nightly-build.yaml/badge.svg)](https://github.com/ProjectPythia/advanced-viz-cookbook/actions/workflows/nightly-build.yaml)
 [![Binder](https://binder.projectpythia.org/badge_logo.svg)](https://binder.projectpythia.org/v2/gh/ProjectPythia/advanced-viz-cookbook.git/main?labpath=notebooks)
 [![DOI](https://zenodo.org/badge/671205314.svg)](https://zenodo.org/badge/latestdoi/671205314)
 


### PR DESCRIPTION
This Cookbook seems to have been missing its nightly build badge.
